### PR TITLE
use StringUtils.isBlank

### DIFF
--- a/src/main/java/com/brightdome/otasco/Otasco.java
+++ b/src/main/java/com/brightdome/otasco/Otasco.java
@@ -129,7 +129,7 @@ public class Otasco {
 
     private static String dependencyFieldName(Field testField) {
         final String dependencyValue = testField.getAnnotation(Dependency.class).value();
-        return StringUtils.isEmpty(dependencyValue) ? testField.getName() : dependencyValue;
+        return StringUtils.isBlank(dependencyValue) ? testField.getName() : dependencyValue;
     }
 
 }


### PR DESCRIPTION
updated Otasco.java to use StringUtils.isBlank rather than the originally implemented StringUtils.isEmpty
